### PR TITLE
NativeOptions is under eframe, not egui.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ mod visuals;
 fn main() {
     eframe::run_native(
         "Egui Themer",
-        egui::NativeOptions::default(),
+        eframe::NativeOptions::default(),
         Box::new(|_| Box::new(Themer::default())),
     )
     .expect("run eframe native app");


### PR DESCRIPTION
(The native build was broken in b0d9cc5. This fixes it.)